### PR TITLE
:ambulance: Fix a bug that caused files to be read incorrectly.

### DIFF
--- a/lib/SourceBuffer.js
+++ b/lib/SourceBuffer.js
@@ -44,6 +44,10 @@ var SourceBuffer = function(buf) {
 	    return buf;
 	},
 
+	readUInt8: function(readPosition) {
+	    return this.readBytesAsUIntBE(1, "UInt8", readPosition);
+	},
+
 	readBytesAsUIntBE: function(length, name="UIntBE", readPosition=null) {
 	    var buf = this.readBytesAsBuffer(length, name, readPosition);
 	    return buf.readUIntBE(0, length);
@@ -96,7 +100,10 @@ var SourceBuffer = function(buf) {
 	    if (writeIndex + writeLength > contentBuf.length) {
 		this.extend(writeIndex + writeLength);
 	    }
-	    contentBuf.write(buf.slice(sourceStart, sourceEnd).toString(), writeIndex, writeLength);
+
+	    for (var x = 0; x < writeLength; x++) {
+		contentBuf.writeUInt8(buf.readUInt8(sourceStart + x), writeIndex + x)
+            }
 
 	    contentLength = Math.max(contentLength, writeIndex + writeLength);
 	},


### PR DESCRIPTION
buf.slice().toString() turns out to be a bad idea. It completely
mangles most files. I didn't notice it in tests because the tests
use string inputs. Instead we are going one byte at a time, using
buf.readUInt8(). There is probably a better way to do this but
it will probably require exposing the node Buffer inside each
SourceBuffer (or, better yet, an overhaul of SourceBuffer that is
much more of a transparent wrapper around Buffer).